### PR TITLE
revert: commander arguments

### DIFF
--- a/lisp/core/exec.el
+++ b/lisp/core/exec.el
@@ -32,10 +32,11 @@
   (eask-defvc< 27 (eask-pkg-init))  ; XXX: remove this after we drop 26.x
   ;; XXX This is the hack by adding all `bin' folders from local elpa.
   (eask-setup-paths)
+  (setq commander-args (cddr argv))  ; by pass `--' as well
   (if-let ((name (eask-argv 1)))
       (or
        ;; 1) For Elisp executable (github-elpa)
-       (let ((program (executable-find name))) (ignore-errors (load program t t)))
+       (let ((program (executable-find name))) (ignore-errors (load program nil t)))
        ;; 2) Execute `shell-command'
        (let* ((program (or (executable-find name) name))
               (commands (cddr (eask-args)))


### PR DESCRIPTION
Commander is a must for elisp executable.