### PR TITLE
Move exec command to node layer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 * Avoid loading package info unless it's needed (#13, #14, and #19)
 * Read `-pkg.el` file prior to package-file while exists (#21)
 * Simplify (rewrite) command exec (#22)
+* Move `exec` command to node layer (#27)
 
 ## 0.6.17
 > Released Mar 5, 2022

--- a/cmds/core/exec.js
+++ b/cmds/core/exec.js
@@ -42,6 +42,10 @@ exports.handler = async (argv) => {
 
   await UTIL.e_call(argv, 'core/exec', '--', cmd);
 
+  if (!fs.existsSync(EASK_HOMEDIR)) {
+    return;
+  }
+
   let epf = EASK_HOMEDIR + 'exec-path';
   let lpf = EASK_HOMEDIR + 'load-path';
 

--- a/cmds/core/exec.js
+++ b/cmds/core/exec.js
@@ -50,7 +50,7 @@ exports.handler = async (argv) => {
 
   let program = cmd[0];
   let rest = cmd.slice(1);
-  let proc = child_process.spawn(program, rest, { stdio: 'inherit' });
+  let proc = child_process.spawn(program, rest, { stdio: 'inherit', shell: true });
 
   proc.on('close', function (code) {
     if (code == 0) return;

--- a/lisp/core/exec.el
+++ b/lisp/core/exec.el
@@ -19,15 +19,6 @@
        (file-name-directory (nth 1 (member "-scriptload" command-line-args))))
       nil t)
 
-(defun eask--shell-command (command)
-  "Wrap `shell-command' with better output to terminal."
-  (eask-info "Start command: %s" command)
-  (let ((code (eask--silent (shell-command command "*output*" "*error*"))))
-    (if (zerop code)
-        (with-current-buffer "*output*" (eask-msg (buffer-string)))
-      (with-current-buffer "*error*" (eask-msg (ansi-red (buffer-string))))
-      (eask-error "Error from the execution, exit code %s" code))))
-
 (defun eask--export-env ()
   "Export environments."
   (let* ((home-dir (getenv "EASK_HOMEDIR"))  ; temporary environment from node
@@ -47,7 +38,10 @@
        ;; 1) For Elisp executable (github-elpa)
        (let ((program (executable-find name))) (ignore-errors (load program nil t)))
        ;; 2) Export load-path and exec-path
-       (eask--export-env))
+       (eask-with-progress
+         "Exporting environments... "
+         (eask--export-env)
+         "done ✓"))
     (eask-info "✗ (No exeuction output)")
     (eask-help 'exec)))
 

--- a/lisp/core/exec.el
+++ b/lisp/core/exec.el
@@ -19,12 +19,14 @@
        (file-name-directory (nth 1 (member "-scriptload" command-line-args))))
       nil t)
 
+(defconst eask--homedir (getenv "EASK_HOMEDIR")  ; temporary environment from node
+  "Eask temporary storage.")
+
 (defun eask--export-env ()
   "Export environments."
-  (let* ((home-dir (getenv "EASK_HOMEDIR"))  ; temporary environment from node
-         (epf (expand-file-name "exec-path" home-dir))
-         (lpf (expand-file-name "load-path" home-dir)))
-    (ignore-errors (make-directory home-dir t))  ; generate dir ~/.eask/
+  (let ((epf (expand-file-name "exec-path" eask--homedir))
+        (lpf (expand-file-name "load-path" eask--homedir)))
+    (ignore-errors (make-directory eask--homedir t))  ; generate dir ~/.eask/
     (write-region (getenv "PATH") nil epf)
     (write-region (getenv "EMACSLOADPATH") nil lpf)))
 
@@ -33,6 +35,7 @@
   ;; XXX This is the hack by adding all `bin' folders from local elpa.
   (eask-setup-paths)
   (setq commander-args (cddr argv))  ; by pass `--' as well
+  (ignore-errors (delete-directory eask--homedir t))
   (if-let ((name (eask-argv 1)))
       (or
        ;; 1) For Elisp executable (github-elpa)

--- a/lisp/core/exec.el
+++ b/lisp/core/exec.el
@@ -34,12 +34,13 @@
   (eask-defvc< 27 (eask-pkg-init))  ; XXX: remove this after we drop 26.x
   ;; XXX This is the hack by adding all `bin' folders from local elpa.
   (eask-setup-paths)
-  (setq commander-args (cddr argv))  ; by pass `--' as well
-  (ignore-errors (delete-directory eask--homedir t))
+  (ignore-errors (delete-directory eask--homedir t))  ; clean up
   (if-let ((name (eask-argv 1)))
       (or
        ;; 1) For Elisp executable (github-elpa)
-       (let ((program (executable-find name))) (ignore-errors (load program nil t)))
+       (let ((program (executable-find name)))
+         (setq commander-args (cddr argv))  ; by pass `--' as well
+         (ignore-errors (load program nil t)))
        ;; 2) Export environments, and return back to node for subcommand execution
        (eask-with-progress
          (ansi-green "Exporting environment PATHs... ")

--- a/lisp/core/exec.el
+++ b/lisp/core/exec.el
@@ -39,9 +39,9 @@
        (let ((program (executable-find name))) (ignore-errors (load program nil t)))
        ;; 2) Export load-path and exec-path
        (eask-with-progress
-         "Exporting environments... "
+         (ansi-green "Exporting environment PATHs... ")
          (eask--export-env)
-         "done ✓"))
+         (ansi-green "done ✓")))
     (eask-info "✗ (No exeuction output)")
     (eask-help 'exec)))
 

--- a/lisp/core/exec.el
+++ b/lisp/core/exec.el
@@ -24,7 +24,7 @@
   (let* ((home-dir (getenv "EASK_HOMEDIR"))  ; temporary environment from node
          (epf (expand-file-name "exec-path" home-dir))
          (lpf (expand-file-name "load-path" home-dir)))
-    (ignore-errors (make-directory home-dir t))
+    (ignore-errors (make-directory home-dir t))  ; generate dir ~/.eask/
     (write-region (getenv "PATH") nil epf)
     (write-region (getenv "EMACSLOADPATH") nil lpf)))
 
@@ -37,7 +37,7 @@
       (or
        ;; 1) For Elisp executable (github-elpa)
        (let ((program (executable-find name))) (ignore-errors (load program nil t)))
-       ;; 2) Export load-path and exec-path
+       ;; 2) Export environments, and return back to node for subcommand execution
        (eask-with-progress
          (ansi-green "Exporting environment PATHs... ")
          (eask--export-env)

--- a/src/util.js
+++ b/src/util.js
@@ -99,9 +99,9 @@ async function e_call(argv, script, ...args) {
     console.log('Executing script inside Emacs...');
     if (argv.verbose == 4)
       console.log('[DEBUG] emacs ' + cmd.join(' '));
-    let process = child_process.spawn('emacs', cmd, { stdio: 'inherit' });
+    let proc = child_process.spawn('emacs', cmd, { stdio: 'inherit' });
 
-    process.on('close', function (code) {
+    proc.on('close', function (code) {
       if (code == 0) {
         resolve(code);
         return;

--- a/src/util.js
+++ b/src/util.js
@@ -82,27 +82,32 @@ function _global_options(argv) {
  * @param { string } args - the rest of the arguments
  */
 async function e_call(argv, script, ...args) {
-  let _script = 'lisp/' + script + '.el';
-  let _path = path.join(plugin_dir(), _script);
+  return new Promise(resolve => {
+    let _script = 'lisp/' + script + '.el';
+    let _path = path.join(plugin_dir(), _script);
 
-  let cmd_base = ['-Q', '--script', _path];
-  let cmd_args = args.flat();
-  let cmd_global = _global_options(argv).flat();
-  let cmd = cmd_base.concat(cmd_args).concat(cmd_global);
-  cmd = _remove_undefined(cmd);
+    let cmd_base = ['-Q', '--script', _path];
+    let cmd_args = args.flat();
+    let cmd_global = _global_options(argv).flat();
+    let cmd = cmd_base.concat(cmd_args).concat(cmd_global);
+    cmd = _remove_undefined(cmd);
 
-  let env_status = (argv.global) ? 'global' : 'development';
-  console.log(`Running Eask in the ${env_status} environment`);
-  console.log('Press Ctrl+C to cancel.');
-  console.log('');
-  console.log('Executing script inside Emacs...');
-  if (argv.verbose == 4)
-    console.log('[DEBUG] emacs ' + cmd.join(' '));
-  let process = child_process.spawn('emacs', cmd, { stdio: 'inherit' });
+    let env_status = (argv.global) ? 'global' : 'development';
+    console.log(`Running Eask in the ${env_status} environment`);
+    console.log('Press Ctrl+C to cancel.');
+    console.log('');
+    console.log('Executing script inside Emacs...');
+    if (argv.verbose == 4)
+      console.log('[DEBUG] emacs ' + cmd.join(' '));
+    let process = child_process.spawn('emacs', cmd, { stdio: 'inherit' });
 
-  process.on('close', function (code) {
-    if (code == 0) return;
-    throw 'Exit with code: ' + code;
+    process.on('close', function (code) {
+      if (code == 0) {
+        resolve(code);
+        return;
+      }
+      throw 'Exit with code: ' + code;
+    });
   });
 }
 


### PR DESCRIPTION
Execute `exec` in the node layer. This mimic Cask's behaviour

https://github.com/cask/cask/blob/bd8aa8297aba1a34f0ff55fd517b431fd0d549cf/bin/cask#L52-L54

This should resolve #12 completely.