### PR TITLE
code: move commands to it's subcommand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 * Read `-pkg.el` file prior to package-file while exists (#21)
 * Simplify (rewrite) command exec (#22)
 * Move `exec` command to node layer (#27)
+* Move `test` and `lint` commands to it's subcommand (#31)
 
 ## 0.6.17
 > Released Mar 5, 2022

--- a/cmds/core/lint.js
+++ b/cmds/core/lint.js
@@ -19,16 +19,10 @@
 
 "use strict";
 
-exports.command = ['checkdoc [files..]'];
-exports.desc = 'run checkdoc';
-exports.builder = {
-  files: {
-    description: 'files you want checkdoc to run on',
-    requiresArg: false,
-    type: 'array',
-  },
+exports.command = ['lint <type>'];
+exports.desc = 'run linter';
+exports.builder = function (yargs) {
+  return yargs.commandDir('../lint/');
 };
 
-exports.handler = async (argv) => {
-  await UTIL.e_call(argv, 'lint/checkdoc', argv.files);
-};
+exports.handler = async (argv) => { };

--- a/cmds/core/test.js
+++ b/cmds/core/test.js
@@ -19,16 +19,10 @@
 
 "use strict";
 
-exports.command = ['checkdoc [files..]'];
-exports.desc = 'run checkdoc';
-exports.builder = {
-  files: {
-    description: 'files you want checkdoc to run on',
-    requiresArg: false,
-    type: 'array',
-  },
+exports.command = ['test <type>'];
+exports.desc = 'run test';
+exports.builder = function (yargs) {
+  return yargs.commandDir('../test/');
 };
 
-exports.handler = async (argv) => {
-  await UTIL.e_call(argv, 'lint/checkdoc', argv.files);
-};
+exports.handler = async (argv) => { };

--- a/cmds/lint/declare.js
+++ b/cmds/lint/declare.js
@@ -19,7 +19,7 @@
 
 "use strict";
 
-exports.command = ['declare [files..]', 'lint-declare [files..]'];
+exports.command = ['declare [files..]'];
 exports.desc = 'run check-declare';
 exports.builder = {
   files: {

--- a/cmds/lint/indent.js
+++ b/cmds/lint/indent.js
@@ -19,7 +19,7 @@
 
 "use strict";
 
-exports.command = ['indent [files..]', 'lint-indent [files..]'];
+exports.command = ['indent [files..]'];
 exports.desc = 'lint the package using indent-lint';
 exports.builder = {
   files: {

--- a/cmds/lint/package.js
+++ b/cmds/lint/package.js
@@ -19,7 +19,7 @@
 
 "use strict";
 
-exports.command = ['lint [files..]', 'lint-package [files..]'];
+exports.command = ['package [files..]'];
 exports.desc = 'lint the package using package-lint';
 exports.builder = {
   files: {

--- a/cmds/lint/regexps.js
+++ b/cmds/lint/regexps.js
@@ -19,7 +19,7 @@
 
 "use strict";
 
-exports.command = ['regexps [files..]', 'lint-regexps [files..]', 'relint [files..]'];
+exports.command = ['regexps [files..]', 'relint [files..]'];
 exports.desc = 'run relint';
 exports.builder = {
   files: {

--- a/docs/content/en/Getting Started/Commands and options.md
+++ b/docs/content/en/Getting Started/Commands and options.md
@@ -343,82 +343,76 @@ $ eask [GLOBAL-OPTIONS] clean-all
 
 Commands that lint your Emacs package.
 
-## 🔍 eask lint [FILES..]
+## 🔍 eask lint package
 
 Lint package using [package-lint](https://github.com/purcell/package-lint).
 
-Alias: `lint-package`
-
 ```sh
-$ eask [GLOBAL-OPTIONS] lint [FILES..]
+$ eask [GLOBAL-OPTIONS] lint package [FILES..]
 ```
 
-## 🔍 eask checkdoc [FILES..]
+## 🔍 eask lint checkdoc
 
 Run checkdoc.
 
 ```sh
-$ eask [GLOBAL-OPTIONS] checkdoc [FILES..]
+$ eask [GLOBAL-OPTIONS] lint checkdoc [FILES..]
 ```
 
-## 🔍 eask elint
+## 🔍 eask lint elint
 
 Run elint.
 
 ```sh
-$ eask [GLOBAL-OPTIONS] elint [FILES..]
+$ eask [GLOBAL-OPTIONS] lint elint [FILES..]
 ```
 
-## 🔍 eask elsa
+## 🔍 eask lint elsa
 
 Run elsa.
 
 ```sh
-$ eask [GLOBAL-OPTIONS] elsa [FILES..]
+$ eask [GLOBAL-OPTIONS] lint lint elsa [FILES..]
 ```
 
-## 🔍 eask indent
-
-Alias: `lint-indent`
+## 🔍 eask lint indent
 
 ```sh
-$ eask [GLOBAL-OPTIONS] indent [FILES..]
+$ eask [GLOBAL-OPTIONS] lint indent [FILES..]
 ```
 
-## 🔍 eask declare
-
-Alias: `lint-declare`
+## 🔍 eask lint declare
 
 ```sh
-$ eask [GLOBAL-OPTIONS] declare [FILES..]
+$ eask [GLOBAL-OPTIONS] lint declare [FILES..]
 ```
 
-## 🔍 eask regexps
+## 🔍 eask lint regexps
 
-Alias: `lint-regexps`, `relint`
+Alias: `lint relint`
 
 ```sh
-$ eask [GLOBAL-OPTIONS] regexps [FILES..]
+$ eask [GLOBAL-OPTIONS] lint regexps [FILES..]
 ```
 
 # 🚩 Testing
 
-## 🔍 eask ert [FILES..]
+## 🔍 eask test ert
 
 ```sh
-$ eask [GLOBAL-OPTIONS] ert [FILES..]
+$ eask [GLOBAL-OPTIONS] test ert [FILES..]
 ```
 
-## 🔍 eask ert-runner [FILES..]
+## 🔍 eask test ert-runner
 
 ```sh
-$ eask [GLOBAL-OPTIONS] ert-runner [FILES..]
+$ eask [GLOBAL-OPTIONS] test ert-runner
 ```
 
-## 🔍 eask buttercup
+## 🔍 eask test buttercup
 
 ```sh
-$ eask [GLOBAL-OPTIONS] buttercup
+$ eask [GLOBAL-OPTIONS] test buttercup
 ```
 
 # 🚩 Utilities

--- a/eask
+++ b/eask
@@ -15,9 +15,9 @@ yargs
   .usage(usage)
   .scriptName('')
   .epilogue(epilogue)
-  .commandDir('cmds/core/', { recurse: true, })
-  .commandDir('cmds/checker/', { recurse: true, })
-  .commandDir('cmds/util/', { recurse: true, })
+  .commandDir('cmds/core/')
+  .commandDir('cmds/checker/')
+  .commandDir('cmds/util/')
   .command({
     command: '*',
     handler() { yargs.showHelp(); }

--- a/eask
+++ b/eask
@@ -15,7 +15,9 @@ yargs
   .usage(usage)
   .scriptName('')
   .epilogue(epilogue)
-  .commandDir('cmds', { recurse: true, })
+  .commandDir('cmds/core/', { recurse: true, })
+  .commandDir('cmds/checker/', { recurse: true, })
+  .commandDir('cmds/util/', { recurse: true, })
   .command({
     command: '*',
     handler() { yargs.showHelp(); }

--- a/lisp/lint/checkdoc.el
+++ b/lisp/lint/checkdoc.el
@@ -4,7 +4,7 @@
 ;;
 ;; Commmand use to run `checkdoc' for all files
 ;;
-;;   $ eask checkdoc
+;;   $ eask lint checkdoc [files..]
 ;;
 ;;
 ;;  Initialization options:

--- a/lisp/lint/declare.el
+++ b/lisp/lint/declare.el
@@ -4,7 +4,7 @@
 ;;
 ;; Commmand use to run `check-declare' for all files
 ;;
-;;   $ eask declare
+;;   $ eask lint declare [files..]
 ;;
 ;;
 ;;  Initialization options:

--- a/lisp/lint/elint.el
+++ b/lisp/lint/elint.el
@@ -4,7 +4,7 @@
 ;;
 ;; Commmand use to run `elint' for all files
 ;;
-;;   $ eask elint
+;;   $ eask lint elint [files..]
 ;;
 ;;
 ;;  Initialization options:

--- a/lisp/lint/elsa.el
+++ b/lisp/lint/elsa.el
@@ -4,7 +4,7 @@
 ;;
 ;; Commmand use to run `elsa' for all files
 ;;
-;;   $ eask elsa
+;;   $ eask lint elsa [files..]
 ;;
 ;;
 ;;  Initialization options:

--- a/lisp/lint/indent.el
+++ b/lisp/lint/indent.el
@@ -4,12 +4,12 @@
 ;;
 ;; Command use to check package with indent-lint,
 ;;
-;;   $ eask indent [names..]
+;;   $ eask lint indent [files..]
 ;;
 ;;
 ;;  Initialization options:
 ;;
-;;    [names..]     files you want indent-lint to run on
+;;    [files..]     files you want indent-lint to run on
 ;;
 
 ;;; Code:

--- a/lisp/lint/package.el
+++ b/lisp/lint/package.el
@@ -1,15 +1,15 @@
-;;; lint.el --- Lint the package using `package-lint'  -*- lexical-binding: t; -*-
+;;; package.el --- Lint the package using `package-lint'  -*- lexical-binding: t; -*-
 
 ;;; Commentary:
 ;;
 ;; Command use to lint current Emacs package,
 ;;
-;;   $ eask lint [names..]
+;;   $ eask lint package [files..]
 ;;
 ;;
 ;;  Initialization options:
 ;;
-;;    [names..]     specify files to do package lint
+;;    [files..]     specify files to do package lint
 ;;
 
 ;;; Code:
@@ -53,4 +53,4 @@
         (eask--print-no-matching-files)
       (eask-help 'lint))))
 
-;;; lint.el ends here
+;;; package.el ends here

--- a/lisp/lint/regexps.el
+++ b/lisp/lint/regexps.el
@@ -4,12 +4,12 @@
 ;;
 ;; Commmand use to run `relint' for all files
 ;;
-;;   $ eask regexps [names..]
+;;   $ eask lint regexps [files..]
 ;;
 ;;
 ;;  Initialization options:
 ;;
-;;    [names..]     files you want relint to run on
+;;    [files..]     files you want relint to run on
 ;;
 
 ;;; Code:

--- a/lisp/test/ert-runner.el
+++ b/lisp/test/ert-runner.el
@@ -4,12 +4,7 @@
 ;;
 ;; Command to run ert tests using ert-runner,
 ;;
-;;   $ eask ert-runner [files..]
-;;
-;;
-;;  Initialization options:
-;;
-;;    [files..]     specify files to run ert tests
+;;   $ eask ert-runner
 ;;
 
 ;;; Code:

--- a/test/commands/local/run.sh
+++ b/test/commands/local/run.sh
@@ -41,13 +41,13 @@ eask activate
 eask recipe
 
 # Linter
-eask lint
-eask checkdoc
-eask declare
-eask elsa
-eask elint
-eask indent
-eask relint
+eask lint package
+eask lint checkdoc
+eask lint declare
+eask lint elsa
+eask lint elint
+eask lint indent
+eask lint relint
 
 # Clean up
 eask clean

--- a/test/commands/test/buttercup/run.sh
+++ b/test/commands/test/buttercup/run.sh
@@ -26,4 +26,4 @@ echo "Test command 'buttercup'..."
 cd $(dirname "$0")
 
 easl install-deps --dev
-eask buttercup
+eask test buttercup

--- a/test/commands/test/ert-runner/run.sh
+++ b/test/commands/test/ert-runner/run.sh
@@ -25,4 +25,4 @@
 echo "Test command 'ert-runner'..."
 cd $(dirname "$0")
 
-eask ert-runner ./test/*.el
+eask test ert-runner ./test/*.el

--- a/test/commands/test/ert/run.sh
+++ b/test/commands/test/ert/run.sh
@@ -25,4 +25,4 @@
 echo "Test command 'ert'..."
 cd $(dirname "$0")
 
-eask ert ./test/*.el
+eask test ert ./test/*.el


### PR DESCRIPTION
1. Move all `test` commands to live under command `eask test`

```
PS C:\Users\XXX\path\to\project> eask test
test <type>

run test

Commands:
  test buttercup [files..]    run buttercup tests
  test ert-runner [files..]   run ert tests using ert-runner
  test ert [files..]          run ert tests

Options:
...
```

2. Move all `lint` commands to live under command `eask lint`

```
PS C:\Users\XXX\path\to\project> eask lint
lint <type>

run linter

Commands:
  lint checkdoc [files..]   run checkdoc
  lint declare [files..]    run check-declare
  lint elint [files..]      run elint
  lint elsa [files..]       run elsa
  lint indent [files..]     lint the package using indent-lint
  lint package [files..]    lint the package using package-lint
  lint regexps [files..]    run relint
Options:
...
```