### PR TITLE
Add regression tests for linting module

### DIFF
--- a/test/mini.emacs.pkg/Eask
+++ b/test/mini.emacs.pkg/Eask
@@ -13,6 +13,7 @@
 (depends-on "emacs" "26.1")
 (depends-on "f")
 (depends-on "s")
+(depends-on "fringe-helper")
 (depends-on "watch-cursor"
             :repo "jcs-elpa/watch-cursor" :fetcher 'github)
 (depends-on "organize-imports-java"

--- a/test/mini.emacs.pkg/mini.emacs.pkg.el
+++ b/test/mini.emacs.pkg/mini.emacs.pkg.el
@@ -7,7 +7,7 @@
 ;; Description: Minimal Emacs package to simulate development environment; only for testing purposes!
 ;; Keyword: test
 ;; Version: 0.0.1
-;; Package-Requires: ((emacs "24.3"))
+;; Package-Requires: ((emacs "24.3") (s "1.12.0") (fringe-helper "1.0.1"))
 ;; URL: https://github.com/emacs-eask/mini.emacs.pkg
 
 ;; This file is NOT part of GNU Emacs.
@@ -33,7 +33,8 @@
 
 ;;; Code:
 
-(require 'cl-lib)
+(require 's)
+(require 'fringe-helper)
 
 (provide 'mini.emacs.pkg)
 ;;; mini.emacs.pkg.el ends here


### PR DESCRIPTION
`eask lint package` was broken without me noticing (fixed in 2165c6bde14bb65979922fa32081089facd80d54), add more tests to prevent this situation happens again.