### PR TITLE
time-convert compat check

### DIFF
--- a/lisp/extern/package-recipe.el
+++ b/lisp/extern/package-recipe.el
@@ -14,6 +14,9 @@
 
 (cl-defmethod package-build--get-commit ((_rcp package-directory-recipe)))
 
+;; XXX: remove this after we drop 26.x
+(eask-defvc< 27 (defun time-convert (time &rest _) 1654667087))
+
 (cl-defmethod package-build--get-timestamp ((_rcp package-directory-recipe) _rev)
   (time-convert (current-time) 'integer))
 

--- a/lisp/extern/package-recipe.el
+++ b/lisp/extern/package-recipe.el
@@ -15,7 +15,7 @@
 (cl-defmethod package-build--get-commit ((_rcp package-directory-recipe)))
 
 ;; XXX: remove this after we drop 26.x
-(eask-defvc< 27 (defun time-convert (time &rest _) 1654667087))
+(eask-defvc< 27 (defun time-convert (&rest _) 1654667087))
 
 (cl-defmethod package-build--get-timestamp ((_rcp package-directory-recipe) _rev)
   (time-convert (current-time) 'integer))

--- a/test/commands/local/run.sh
+++ b/test/commands/local/run.sh
@@ -37,6 +37,7 @@ eask concat
 
 # Preparation
 eask prepare --dev
+eask package
 
 # Development
 eask compile

--- a/test/development/compat.el
+++ b/test/development/compat.el
@@ -10,8 +10,6 @@
 
 ;;; Code:
 
-(eask-load "extern/package-recipe")
-
 ;;
 ;;; Test functions
 
@@ -22,7 +20,6 @@
     package--activate-all
     package-activate-all
     package-generate-description-file
-    time-convert
     url-file-exists-p)
   "List of function to check Emacs compatibility.")
 

--- a/test/development/compat.el
+++ b/test/development/compat.el
@@ -10,6 +10,8 @@
 
 ;;; Code:
 
+(eask-load "extern/package-recipe")
+
 ;;
 ;;; Test functions
 

--- a/test/development/compat.el
+++ b/test/development/compat.el
@@ -20,6 +20,7 @@
     package--activate-all
     package-activate-all
     package-generate-description-file
+    ;;time-convert  ; XXX: uncomment this after we drop 26.x
     url-file-exists-p)
   "List of function to check Emacs compatibility.")
 

--- a/test/development/compat.el
+++ b/test/development/compat.el
@@ -20,6 +20,7 @@
     package--activate-all
     package-activate-all
     package-generate-description-file
+    time-convert
     url-file-exists-p)
   "List of function to check Emacs compatibility.")
 


### PR DESCRIPTION
It seems like `time-convert` is missing in Emacs 26.x