### PR TITLE
Add bug-reference-bug-mode reference to FAQ

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -1,0 +1,4 @@
+;;; Directory Local Variables
+;;; For more information see (info "(emacs) Directory Variables")
+
+((markdown-mode . ((fill-column . 80))))

--- a/docs/content/en/FAQ/_index.md
+++ b/docs/content/en/FAQ/_index.md
@@ -72,3 +72,18 @@ like this:
 
 (depends-on "helm")
 ```
+
+## ❓ Why am I getting git errors with status 2?
+
+If you get this sample error message
+```
+Loading package information... done ✓
+  - Installing s (20210616.619)... Failed (status 2): git --no-pager remote get-url upstream .
+...
+```
+
+You may have `bug-reference-prog-mode` enabled. It is not yet compatible with Eask and
+should be disabled when running any of Eask’s commands.
+
+See [this issue](https://github.com/emacs-eask/eask/issues/39#issuecomment-1150770740) for
+more information.


### PR DESCRIPTION
This commit adds a reference to #39 in the FAQ.

It also adds `.dir-locals.el` for column width in Markdown files. I’m not sure which value you’re using on your setup --- mine is 70 by default, so definitively not what I can see in the markdown files. Let me know if I have to change that.